### PR TITLE
allow to omit front-end stuff

### DIFF
--- a/lib/before.js
+++ b/lib/before.js
@@ -32,6 +32,10 @@ module.exports = function before (scope, sb) {
 		website: util.format('http://github.com/%s', scope.github.username)
 	});
 
+	if (scope.frontend === false) {
+  		scope.modules['frontend'] = scope.modules['gruntfile'] = false;
+  	}
+
 	// Make changes to the rootPath where the sails project will be created
 	scope.rootPath = path.resolve(process.cwd(), args0 || '');
 


### PR DESCRIPTION
Add '--no-frontend' option which allows to omit the assets folder and front-end-oriented Grunt tasks.
This feature is mentioned in the docs http://beta.sailsjs.org/#/getStarted

> You can also run sails new myCoolApi --no-frontend to omit the assets folder and front-end-oriented Grunt tasks for future projects.  

It works, but I'm not sure I've done it right. Is it ok to skip generators like this? https://github.com/t3chnoboy/sails-generate-new/blob/master/lib/before.js#L36
closes https://github.com/balderdashy/sails/issues/1734
