### PR TITLE
Fixing coffee generator

### DIFF
--- a/json/sailsrc.js
+++ b/json/sailsrc.js
@@ -16,8 +16,7 @@ module.exports = function(scope) {
 	// 
 	
 	if (scope.coffee) {
-		package.generators.modules.model = 'sails-generate-model-coffee';
-		package.generators.modules.controller = 'sails-generate-controller-coffee';
+		package.generators.coffee = true;
 	}
 
 	return package;


### PR DESCRIPTION
Since sails-generator-* now support coffee scope flag and we don't have coffee packages, we should add this flag here or even disable it at all