### PR TITLE
Exports app.js function

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -23,7 +23,7 @@
 process.chdir(__dirname);
 
 // Ensure a "sails" can be located:
-(function() {
+var app = module.exports = function() {
   var sails;
   try {
     sails = require('sails');
@@ -56,4 +56,6 @@ process.chdir(__dirname);
 
   // Start server
   sails.lift(rc('sails'));
-})();
+}
+
+app();


### PR DESCRIPTION
This doesn't change the functionality of the generated app.js file at all, but exports what was an IIFE.

The idea behind this change came from https://github.com/balderdashy/sails/issues/2926, which is to have sails lift use app.js if it exists. I have this functionality working locally by attempting to `require` the app.js file in a try/catch block. This would be useful if the app author has customized the file in anyway with analytics or other packages.

Thoughts?